### PR TITLE
Improve accessibility

### DIFF
--- a/src/css/college-costs/nav.less
+++ b/src/css/college-costs/nav.less
@@ -20,7 +20,7 @@
       }
 
       .o-secondary-nav_link {
-        border: none;
+        border-width: 0;
         font-weight: normal;
         color: @black;
         padding: unit( 5px / @base-font-size-px, em ) 0;
@@ -32,7 +32,6 @@
 
         &:focus {
           font-weight: 600;
-          outline: 0;
         }
       }
 
@@ -41,7 +40,11 @@
         display: none;
       }
 
-      li.o-secondary-nav_list-item__parent[data-nav-is-active='True'] > a {
+      button {
+        background-color: transparent;
+      }
+
+      li.o-secondary-nav_list-item__parent[data-nav-is-active='True'] > button {
         font-weight: 600;
       }
 
@@ -52,14 +55,14 @@
         }
       }
 
-      .o-secondary-nav_list-item__parent li[data-nav-is-active='True'] {
-        .active-section {
-          border-left: 3px solid @brand-color-primary;
+      li[data-nav_item] {
+        cursor: pointer;
+      }
 
-          a {
-            font-weight: 600;
-          }
-        }
+      .o-secondary-nav_list-item__parent [data-nav-is-active='True'].active-section {
+        border-left: 3px solid @brand-color-primary;
+        position: relative;
+        left: -3px;
       }
     } );
   }

--- a/src/css/college-costs/state-based.less
+++ b/src/css/college-costs/state-based.less
@@ -17,11 +17,8 @@ main.college-costs {
 
   // 2 vs 4 year
   &[data-state_communitycollege='true'] {
-    span.community-college {
-      display: inline;
-    }
-    tr.community-college {
-      display: table-row;
+    .community-college {
+      display: revert;
     }
     span.four-year-college {
       display: none;
@@ -32,10 +29,7 @@ main.college-costs {
   &[data-state_programlevel='undergrad'] {
     &[data-state_programdependency='dependent'] {
       .dependent-content {
-        display: block;
-      }
-      span.dependent-content {
-        display: inline;
+        display: revert;
       }
       .independent-content {
         display: none;
@@ -44,10 +38,7 @@ main.college-costs {
 
     &[data-state_programdependency='independent'] {
       .independent-content {
-        display: block;
-      }
-      span.independent-content {
-        display: inline;
+        display: revert;
       }
       .dependent-content {
         display: none;
@@ -55,16 +46,7 @@ main.college-costs {
     }
 
     .undergrad-content {
-      display: block;
-    }
-    span.undergrad-content {
-      display: inline;
-    }
-    li.undergrad-content {
-      display: list-item;
-    }
-    tr.undergrad-content {
-      display: table-row;
+      display: revert;
     }
   }
 
@@ -76,37 +58,19 @@ main.college-costs {
 
   &[data-state_programlevel='graduate'] {
     .graduate-content {
-      display: block;
-    }
-    span.graduate-content {
-      display: inline;
-    }
-    li.graduate-content {
-      display: list-item;
-    }
-    tr.graduate-content {
-      display: table-row;
+      display: revert;
     }
   }
 
   &[data-state_programtype='associates'] {
     .associates-content {
-      display: block;
-    }
-    span.associates-content {
-      display: inline;
-    }
-    li.associates-content {
-      display: list-item;
-    }
-    tr.associates-content {
-      display: table-row;
+      display: revert;
     }
   }
 
   &[data-state_programtype][data-state_schoolhasprograms='yes'] {
     .program-select {
-      display: block;
+      display: revert;
     }
   }
 
@@ -114,19 +78,19 @@ main.college-costs {
 
   &[data-state_private-loan-section='active'] {
     .private-loan-section {
-      display: block;
+      display: revert;
     }
   }
 
   &[data-state_parentplus-loan-section='active'] {
     .parentplus-loan-section {
-      display: block;
+      display: revert;
     }
   }
 
   &[data-state_gradplus-loan-section='active'] {
     .gradplus-loan-section {
-      display: block;
+      display: revert;
     }
   }
 
@@ -150,7 +114,7 @@ main.college-costs {
     }
 
     .college-costs_tool-section.active {
-      display: block;
+      display: revert;
     }
   }
 
@@ -201,44 +165,29 @@ main.college-costs {
   // Program selection visibility
   &[data-state_schoolhasprograms='yes'] {
     [data-state-based-visibility='school-has-programs'] {
-      display: block;
-    }
-    span[data-state-based-visibility='school-has-programs'] {
-      display: inline;
+      display: revert;
     }
   }
   &[data-state_schoolhasprograms='no'] {
     [data-state-based-visibility='school-no-programs'] {
-      display: block;
-    }
-    span[data-state-based-visibility='school-no-programs'] {
-      display: inline;
+      display: revert;
     }
   }
 
   &[data-state_pid] {
     [data-state-based-visibility='program-is-selected'] {
-      display: block;
-    }
-    span[data-state-based-visibility='program-is-selected'] {
-      display: inline;
+      display: revert;
     }
   }
   &:not([data-state_pid]) {
     [data-state-based-visibility='no-program-selected'] {
-      display: block;
-    }
-    span[data-state-based-visibility='no-program-selected'] {
-      display: inline;
+      display: revert;
     }
   }
 
   &[data-state_programtype='graduate']:not([data-state_pid]) {
     [data-state-based-visibility='no-program-selected'] {
-      display: block;
-    }
-    span[data-state-based-visibility='no-program-selected'] {
-      display: inline;
+      display: revert;
     }
 
     .college-costs_tool-section.college-costs_tool-section__affording
@@ -304,19 +253,13 @@ main.college-costs {
 
   &[data-state_debtruleviolation='true'] {
     [data-state-based-visibility='debt-rule-violation'] {
-      display: block;
-    }
-    span[data-state-based-visibility='debt-rule-violation'] {
-      display: inline;
+      display: revert;
     }
   }
 
   &[data-state_debtruleviolation='false'] {
-    span[data-state-based-visibility='debt-rule-passed'] {
-      display: inline;
-    }
-    [data-state-based-visibility='debt-rule-okay'] {
-      display: block;
+    [data-state-based-visibility='debt-rule-passed'] {
+      display: revert;
     }
   }
 

--- a/src/js/college-costs/views/app-view.js
+++ b/src/js/college-costs/views/app-view.js
@@ -55,8 +55,8 @@ const appView = {
     if (navigator.clipboard) {
       navigator.clipboard.writeText(window.location.href).then(function () {
         const btn = event.target.closest('button');
-        const copyBtnDefaultText = btn.querySelector('#default-text');
-        const copyBtnSuccessText = btn.querySelector('#success-text');
+        const copyBtnDefaultText = btn.querySelector('.default-text');
+        const copyBtnSuccessText = btn.querySelector('.success-text');
         copyBtnDefaultText.classList.add(HIDDEN_CLASS);
         copyBtnSuccessText.classList.remove(HIDDEN_CLASS);
         setTimeout(function () {

--- a/src/js/college-costs/views/navigation-view.js
+++ b/src/js/college-costs/views/navigation-view.js
@@ -14,7 +14,7 @@ const navigationView = {
   _navMenu: null,
   _navListItems: null,
   _navItems: null,
-  _navButtons: null,
+  // _navButtons: null,
   _nextButton: null,
   _appSegment: null,
   _stateDomElem: null,
@@ -44,13 +44,13 @@ const navigationView = {
     // clear active-sections
     navigationView._navItems.forEach((elem) => {
       elem.classList.remove('active-section');
-      elem.setAttribute('aria-selected', false);
     });
 
     const navItem = document.querySelector(
       '[data-nav_item="' + activeName + '"]'
     );
-    const activeElem = navItem.closest('li');
+    // const activeElem = navItem.closest('li');
+    const activeElem = navItem;
     const activeParent = activeElem.closest(
       '.o-secondary-nav_list-item__parent'
     );
@@ -61,10 +61,8 @@ const navigationView = {
     });
 
     activeElem.setAttribute('data-nav-is-active', 'True');
-    activeElem.setAttribute('aria-selected', true);
     activeParent.setAttribute('data-nav-is-open', 'True');
     activeParent.setAttribute('data-nav-is-active', 'True');
-    activeElem.setAttribute('aria-selected', true);
     activeParent
       .querySelectorAll('.o-secondary-nav_list__children li')
       .forEach((elem) => {
@@ -127,7 +125,7 @@ const navigationView = {
    */
   init: function (body, iped) {
     this._navMenu = body.querySelector('.o-secondary-nav');
-    this._navButtons = body.querySelectorAll('.o-secondary-nav a');
+    this._navButtons = body.querySelectorAll('.o-secondary-nav button');
     this._navListItems = body.querySelectorAll('.o-secondary-nav li');
     this._navItems = body.querySelectorAll('[data-nav_item]');
     this._nextButton = body.querySelector(
@@ -158,6 +156,9 @@ const navigationView = {
  * @param { string } iped - String representing the chosen school.
  */
 function _addButtonListeners(iped) {
+  navigationView._navItems.forEach((elem) => {
+    elem.addEventListener('click', _handleNavButtonClick);
+  });
   navigationView._navButtons.forEach((elem) => {
     elem.addEventListener('click', _handleNavButtonClick);
   });

--- a/src/templates/_body.html
+++ b/src/templates/_body.html
@@ -29,7 +29,8 @@
             <div class="content_main
                         content__flush-top-on-small
                         content__half-top-on-desk
-                        content__flush-bottom">
+                        content__flush-bottom"
+                 id="content_main">
                 <div class="app-container">
                     <div class="app">
                         {%- include 'sections/01-school-search.html' -%}

--- a/src/templates/_nav.html
+++ b/src/templates/_nav.html
@@ -1,10 +1,14 @@
 {% import 'macros/organisms/secondary-nav.html' as secondary_nav with context %}
 
-<aside class="content_sidebar
-              content__flush-top-on-small
-              content__flush-sides-on-small
-              content__half-top-on-desk
-              o-college-costs-nav">
+<div class="skip-nav">
+    <a class="skip-nav_link" href="#content_main">Skip navigation</a>
+</div>
+
+<div class="content_sidebar
+            content__flush-top-on-small
+            content__flush-sides-on-small
+            content__half-top-on-desk
+            o-college-costs-nav">
     {% set nav_items = [
         {
             'title': 'Your financial aid offer',
@@ -59,4 +63,4 @@
         }
     ] %}
     {{ secondary_nav.render(nav_items) }}
-</aside>
+</div>

--- a/src/templates/macros/organisms/copy-link-form.html
+++ b/src/templates/macros/organisms/copy-link-form.html
@@ -1,13 +1,12 @@
 <div class="o-form_group">
     <div class="m-form-field">
-        <label class="a-label a-label__heading" for="finish_link">
+        <label class="a-label a-label__heading">
             Your link
         </label>
-        <pre id="finish_link" name="finish_link" data-app-save-link="save-and-finish"></pre>
-        <button class="a-btn u-mt15 copy-your-link"
-                aria-live="polite">
-          <span id="default-text">Copy<span class="u-visually-hidden">your link to the clipboard</span></span>
-          <span id="success-text" class="u-hidden"><span class="u-visually-hidden">Your link was </span>Copied!</span>
+        <pre data-app-save-link="save-and-finish" aria-label="Your link"></pre>
+        <button class="a-btn u-mt15 copy-your-link" aria-live="polite">
+            <span class="default-text">Copy<span class="u-visually-hidden">your link to the clipboard</span></span>
+            <span class="success-text u-hidden"><span class="u-visually-hidden">Your link was </span>Copied!</span>
         </button>
     </div>
 </div>

--- a/src/templates/macros/organisms/secondary-nav.html
+++ b/src/templates/macros/organisms/secondary-nav.html
@@ -13,11 +13,10 @@
    ========================================================================== #}
 
 {% macro render( nav_items ) %}
-<nav class="o-secondary-nav"
-     aria-label="Section navigation">
+<nav class="o-secondary-nav">
     <button class="o-secondary-nav_header" type="button" aria-expanded="false">
         <span class="o-secondary-nav_label">
-            In this section
+            Navigation
         </span>
         <span class="o-secondary-nav_cues">
             <span class="o-secondary-nav_cue-open" aria-label="Show">
@@ -31,38 +30,34 @@
 
     <div class="o-secondary-nav_content">
         <ul class="o-secondary-nav_list
-                   o-secondary-nav_list__parents" role="tablist">
+                   o-secondary-nav_list__parents">
         {%- for item in nav_items %}
             {# TODO: refactor JS to rid of custom `o-secondary-nav_li__parent` #}
             <li class="o-secondary-nav_list-item__parent"
                 data-nav-is-active="{{item.current if item.current else 'False'}}"
-                data-nav-is-open="False"
-                role="tab">
-                <a class="o-secondary-nav_link
-                          o-secondary-nav_link__parent"
-                    href="#"
-                    data-gtm_ignore="true"
-                    data-nav_section="{{ item.data }}">
+                data-nav-is-open="False">
+                <button class="o-secondary-nav_link
+                               o-secondary-nav_link__parent"
+                        data-gtm_ignore="true"
+                        data-nav_section="{{ item.data }}">
                     {{ item.title }}
-                </a>
+                </button>
             {%- if item.children -%}
                 <ul class="o-secondary-nav_list
                            o-secondary-nav_list__children"
-                    role="tablist">
+                    aria-live="polite">
                 {%- for child in item.children -%}
-                    <li role="tab">
-                        <a class="o-secondary-nav_link"
-                           href="#"
-                           data-gtm_ignore="true"
-                           data-nav_item="{{ child.data }}">
-                          {{ child.title }}
-                        </a>
+                    <li>
+                        <button class="o-secondary-nav_link"
+                                data-gtm_ignore="true"
+                                data-nav_item="{{ child.data }}">
+                            {{ child.title }}
+                        </button>
                     </li>
                 {%- endfor %}
                 </ul>
             {%- endif -%}
             </li>
-
         {%- endfor %}
         </ul>
     </div>

--- a/src/templates/sections/01-school-search.html
+++ b/src/templates/sections/01-school-search.html
@@ -83,7 +83,7 @@
         </div>
 
         <div class="block block__sub program-select">
-          <h3 class="h4">Select your program</h3>
+          <label class="a-label a-label__heading u-mb15" for="program-select">Select your program</label>
           <div class="a-select">
             <select id="program-select">
 

--- a/src/templates/sections/09-make-a-plan.html
+++ b/src/templates/sections/09-make-a-plan.html
@@ -475,14 +475,8 @@
                 <h3 class="other-loan-options">Additional loan options</h3>
                 <p> If you still have uncovered costs after working with the financial aid office to exhaust all the options listed above, you and your family have two more loan options to consider: </p>
                 <ul>
-                    <div class="dependent-content">
-                        <li><strong>Federal Parent PLUS loan</strong>: For dependent students at participating schools, parents and stepparents may be able to apply for a Parent PLUS loan from the U.S. Department of Education. Check with the financial aid office before including this in your plan.</li>
-                    </div>
-
-                    <div class="graduate-content">
-                        <li><strong>Direct PLUS loan (aka Grad PLUS)</strong>: Graduate students can apply for a Direct PLUS loan from the U.S. Department of Education.</li>
-                    </div>
-
+                    <li class="dependent-content"><strong>Federal Parent PLUS loan</strong>: For dependent students at participating schools, parents and stepparents may be able to apply for a Parent PLUS loan from the U.S. Department of Education. Check with the financial aid office before including this in your plan.</li>
+                    <li class="graduate-content"><strong>Direct PLUS loan (aka Grad PLUS)</strong>: Graduate students can apply for a Direct PLUS loan from the U.S. Department of Education.</li>
                     <li><strong>Private student loan</strong>: You or a family member can apply for a private student loan from a bank or credit union. Students without credit history are typically required to have a family member cosign as a fellow borrower on the loan.</li>
                 </ul>
                 {{ notification.render(
@@ -490,17 +484,11 @@
                     true,
                     'Know before you go',
                     '<ul>
-                        <div class="dependent-content">
-                            <li><strong>Accessibility</strong>: <span class="undergrad-content">Parent</span><span class="graduate-content">Grad</span> PLUS Loans are typically easier to qualify for than private loans. All borrowers can save money by comparison shopping—apply to multiple lenders to get the best terms.</li>
-                        </div>
+                        <li class="dependent-content"><strong>Accessibility</strong>: <span class="undergrad-content">Parent</span><span class="graduate-content">Grad</span> PLUS Loans are typically easier to qualify for than private loans. All borrowers can save money by comparison shopping—apply to multiple lenders to get the best terms.</li>
 
-                        <div class="dependent-content">
-                            <li><strong>Cost</strong>: For borrowers and cosigners with strong credit, private loans may offer lower interest rates than <span class="undergrad-content">Parent</span> <span class="graduate-content">Grad</span> PLUS loans&mdash;but watch out for variable interest rates, which can increase in the future. Any borrower can save money on interest by starting repayment as soon as possible.</li>
-                        </div>
+                        <li class="dependent-content"><strong>Cost</strong>: For borrowers and cosigners with strong credit, private loans may offer lower interest rates than <span class="undergrad-content">Parent</span> <span class="graduate-content">Grad</span> PLUS loans&mdash;but watch out for variable interest rates, which can increase in the future. Any borrower can save money on interest by starting repayment as soon as possible.</li>
 
-                        <div class="independent-content">
-                            <li><strong>Cost</strong>: You may be able to reduce the cost of the loan by comparison shopping — apply to multiple lenders to get the best terms. Watch out for variable interest rates, which can increase in the future. You can save money on interest by starting repayment as soon as possible.</li>
-                        </div>
+                        <li class="independent-content"><strong>Cost</strong>: You may be able to reduce the cost of the loan by comparison shopping — apply to multiple lenders to get the best terms. Watch out for variable interest rates, which can increase in the future. You can save money on interest by starting repayment as soon as possible.</li>
 
                         <li><strong>Protections</strong>: <span class="dependent-content">Parent PLUS loans offer some, but not all, of the protections as Federal Direct Loans to students.</span> Private loans are not legally required to offer the same borrower protections and repayment options as any federal loans.</li>
 
@@ -599,7 +587,7 @@
                             'information',
                             true,
                             '',
-                            'More details about parent PLUS loans can be found on the <a href="https://studentaid.gov/understand-aid/types/loans/plus/parent" target="_blank" class="external-link" rel="noreferrer noopener">Federal Student Aid website.</a></span>' | safe
+                            'More details about parent PLUS loans can be found on the <a href="https://studentaid.gov/understand-aid/types/loans/plus/parent" target="_blank" class="external-link" rel="noreferrer noopener">Federal Student Aid website.</a>' | safe
                         ) }}
                     {% endcall %}
                 </div>

--- a/src/templates/sections/10-max-debt-guideline.html
+++ b/src/templates/sections/10-max-debt-guideline.html
@@ -1,5 +1,5 @@
 <section class="college-costs_tool-section college-costs_tool-section__debt-guideline" data-tool-section="max-debt-guideline">
-    <h1>Could this be too much debt?</h1>
+    <h2 tabindex="-1">Could this be too much debt?</h2>
     <p class="lead-paragraph"><strong>A common guideline:</strong> Keep your student loan total below your first-year salary out of school. If your debt will be higher than your salary, consider whether it might be more debt than you can afford.</p>
 
     <h2 tabindex="-1">1. Estimate your total debt at graduation.</h2>
@@ -76,7 +76,7 @@
             ) }}
         </div>
 
-        <div data-state-based-visibility="debt-rule-okay">
+        <div data-state-based-visibility="debt-rule-passed">
             {{ notification.render(
                 'information',
                 true,

--- a/src/templates/sections/11-cost-of-borrowing.html
+++ b/src/templates/sections/11-cost-of-borrowing.html
@@ -1,8 +1,8 @@
 <section class="college-costs_tool-section college-costs_tool-section__cost-of-borrowing" data-tool-section="cost-of-borrowing">
-    <h1 tabindex="-1">What will interest cost me?</h1>
+    <h2 tabindex="-1">What will interest cost me?</h2>
     <p class="lead-paragraph"> This page shows the total cost of borrowing if you repay your debt over 10 years on the standard repayment plan. Other plans may be available with lower monthly payments, but the total cost of borrowing will be higher.</p>
 
-    <h2 tabindex="-1">Estimated total cost of these loans with a standard 10-year repayment plan: <strong><span data-financial-item="debt_tenYearTotal"></span></strong></h2>
+    <h3 tabindex="-1">Estimated total cost of these loans with a standard 10-year repayment plan: <strong><span data-financial-item="debt_tenYearTotal"></span></strong></h3>
 
     <div class="college-costs_chart" id="cost-of-borrowing_chart"></div>
 

--- a/src/templates/sections/12-affording-your-loan.html
+++ b/src/templates/sections/12-affording-your-loan.html
@@ -1,5 +1,5 @@
 <section class="college-costs_tool-section college-costs_tool-section__affording" data-tool-section="affording-your-loans">
-    <h1 tabindex="-1">Can I afford my payment?</h1>
+    <h2 tabindex="-1">Can I afford my payment?</h2>
 
     <p class="lead-paragraph">Making loan payments on time can help you avoid financial and legal problems. Default—missing too many payments—can result in low credit scores, additional fees, wage garnishment, and ineligibility for further federal student aid.</p>
 

--- a/src/templates/sections/14-summary.html
+++ b/src/templates/sections/14-summary.html
@@ -309,59 +309,57 @@
         <div class="block">
             <h3 class="summary_header">Worth your investment?</h3>
 
-        <div class="o-expandable-group">
             <table class="o-table u-w100pct">
-            <thead>
-                <tr>
-                    <th scope="col" class="u-w70pct">
-                        <p>Graduation and repayment rates</p>
-                    </th>
-                    <th scope="col">
-                        <p></p>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td><p>Graduation rate</p></td>
-                    <td>
-                        <span class="undergrad-content">
-                            <span data-school-item="rateGraduationText"></span>
-                        </span>
-                        <span class="graduate-content">
-                            <span>Ask the school</span>
-                        </span>
-                    </td>
-                </tr>
-                <tr class="community-college">
-                    <td><p>Transfer to graduation rate</p></td>
-                    <td><span data-school-item=""></span></td>
-                </tr>
-                <tr>
-                    <td><p>Default rate</p></td>
-                    <td>
-                        <span class="undergrad-content">
-                            <span data-school-item="defaultRateText"></span>
-                        </span>
-                        <span class="graduate-content">
-                            <span>Ask the school</span>
-                        </span>
-                    </td>
-                </tr>
-                <tr>
-                    <td><p>Repayment rate</p></td>
-                    <td>
-                        <span class="undergrad-content">
-                            <span data-school-item="rateRepay3yrText"></span>
-                        </span>
-                        <span class="graduate-content">
-                            <span>Ask the school</span>
-                        </span>
-                    </td>
-                </tr>
-            </tbody>
-        </table>
-
-
+                <thead>
+                    <tr>
+                        <th scope="col" class="u-w70pct">
+                            <p>Graduation and repayment rates</p>
+                        </th>
+                        <th scope="col">
+                            <p>Percent</p>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><p>Graduation rate</p></td>
+                        <td>
+                            <span class="undergrad-content">
+                                <span data-school-item="rateGraduationText"></span>
+                            </span>
+                            <span class="graduate-content">
+                                <span>Ask the school</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="community-college">
+                        <td><p>Transfer to graduation rate</p></td>
+                        <td><span data-school-item=""></span></td>
+                    </tr>
+                    <tr>
+                        <td><p>Default rate</p></td>
+                        <td>
+                            <span class="undergrad-content">
+                                <span data-school-item="defaultRateText"></span>
+                            </span>
+                            <span class="graduate-content">
+                                <span>Ask the school</span>
+                            </span>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><p>Repayment rate</p></td>
+                        <td>
+                            <span class="undergrad-content">
+                                <span data-school-item="rateRepay3yrText"></span>
+                            </span>
+                            <span class="graduate-content">
+                                <span>Ask the school</span>
+                            </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </section>


### PR DESCRIPTION
Improve various accessibility issues identified by Axe and manual testing.


## Additions

- Adds a second skip link to skip from the top of the navigation to the main content


## Changes

- Simplifies side navigation
- Makes headings consistent
- Ensures valid HTML


## Testing

1. Run Axe against various screens within the app
   - One common finding will appear on screens of the tool beyond the welcome page: missing H1. I don't believe this is an issue in practice, given the nature of the tool as a single-page app.
   - There are also a few heading hierarchy issues within the Highcharts-generated code, but I'm not familiar enough with that to know how to fix those. Perhaps @mistergone or @anselmbradford could weigh in?
1. Test the app using keyboard navigation
1. Test the app with a screen reader


## Todos

- There are a couple accessibility issues within the CostsGroup component that will be addressed in a forthcoming PR that refactors that component.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)

## Testing checklist

### Browsers

- [x] Chrome/Edge
- [x] Firefox
- [x] Safari
- [ ] iOS Safari
- [ ] Chrome for Android
